### PR TITLE
feat: add ViewModels for OnBoarding, AddTransaction, and AddGoal scre…

### DIFF
--- a/iosApp/iosApp/screen/addGoal/AddGoalViewModel.swift
+++ b/iosApp/iosApp/screen/addGoal/AddGoalViewModel.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Shared
+import Combine
+import KMPNativeCoroutinesCombine
+
+final class AddGoalViewModel: ObservableObject {
+    
+    @Published var uiState: AddGoalState = AddGoalState.companion.default()
+    @Published var uiEffect: AddGoalEffect? = nil
+    
+    private let viewModel: AddGoalViewModelKt = Koin.shared.get()
+    private var stateCancellable: AnyCancellable?
+    private var effectCancellable: AnyCancellable?
+    
+    func initData(goalId: Int64){
+        viewModel.doInitData(goalId: goalId)
+        observeUiState()
+        observeUiEffect()
+    }
+    
+    func handle(event: AddGoalEvent) {
+        viewModel.handleEvent(event: event)
+    }
+    
+    private func observeUiState() {
+        let publisher = createPublisher(for: viewModel.uiStateFlow)
+        stateCancellable = publisher.sink{ completion in
+            print("completion: \(completion)")
+        } receiveValue: { [weak self] state in
+            self?.update(state: state)
+        }
+    }
+    
+    private func update(state: AddGoalState){
+        DispatchQueue.main.async {
+            self.uiState = state
+        }
+    }
+    
+    private func observeUiEffect(){
+        let publisher = createPublisher(for: viewModel.uiEffect)
+        effectCancellable = publisher.sink{ completion in
+            print("completion \(completion)")
+        } receiveValue: { [weak self] effect in
+            self?.update(effect: effect)
+        }
+    }
+    
+    private func update(effect: AddGoalEffect){
+        DispatchQueue.main.async {
+            self.uiEffect = effect
+        }
+    }
+    
+    deinit {
+        stateCancellable?.cancel()
+        effectCancellable?.cancel()
+    }
+}

--- a/iosApp/iosApp/screen/addTransaction/AddTransactionViewModel.swift
+++ b/iosApp/iosApp/screen/addTransaction/AddTransactionViewModel.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Shared
+import Combine
+import KMPNativeCoroutinesCombine
+
+final class AddTransactionViewModel: ObservableObject {
+    
+    @Published var uiState: AddTransactionState = AddTransactionState.companion.default()
+    private let viewModel: AddTransactionViewModelKt = Koin.shared.get()
+    private var uiStateCancellable: AnyCancellable?
+    
+    func initializeData(transactionId: Int64) {
+        viewModel.initializeData(id: transactionId)
+        observeUiState()
+    }
+    
+    
+    func handle(event: AddTransactionEvent) {
+        viewModel.handleEvent(event: event)
+    }
+    
+    private func observeUiState() {
+        let publisher = createPublisher(for: viewModel.uiStateFlow)
+        uiStateCancellable = publisher.sink{ completion in
+            print("complete: \(completion)")
+        } receiveValue: { [weak self] state in
+            self?.update(state: state)
+        }
+    }
+    
+    private func update(state: AddTransactionState) {
+        DispatchQueue.main.async {
+            self.uiState = state
+        }
+    }
+    
+    deinit {
+        uiStateCancellable?.cancel()
+    }
+}

--- a/iosApp/iosApp/screen/onBoarding/OnBoardingViewModel.swift
+++ b/iosApp/iosApp/screen/onBoarding/OnBoardingViewModel.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Shared
+import KMPNativeCoroutinesCombine
+import Combine
+
+final class OnBoardingViewModel: ObservableObject {
+    
+    @Published private(set) var uiState: OnBoardingState = OnBoardingState.companion.default()
+    @Published var uiEffect: OnBoardingEffect? = nil
+
+    private let viewModel: OnBoardingViewModelKt = Koin.shared.get()
+    private var stateCancellable: AnyCancellable?
+    private var effectCancellable: AnyCancellable?
+    
+    func initData() {
+        observeUiState()
+        observeUiEffect()
+    }
+    
+    func handle(event: OnBoardingEvent) {
+        viewModel.handleEvent(event: event)
+    }
+    
+    private func observeUiState() {
+        let publisher = createPublisher(for: viewModel.uiStateFlow)
+        stateCancellable = publisher.sink { completion in
+            print("completion \(completion)")
+        } receiveValue: { [weak self] state in
+            self?.update(state: state)
+        }
+    }
+    
+    private func update(state: OnBoardingState) {
+        DispatchQueue.main.async {
+            self.uiState = state
+        }
+    }
+    
+    private func observeUiEffect() {
+        let publisher = createPublisher(for: viewModel.uiEffect)
+        effectCancellable = publisher.sink { completion in
+            print("completion \(completion)")
+        } receiveValue: { [weak self] effect in
+            self?.update(effect: effect)
+        }
+    }
+    
+    private func update(effect: OnBoardingEffect) {
+        DispatchQueue.main.async {
+            self.uiEffect = effect
+        }
+    }
+    
+    deinit {
+        stateCancellable?.cancel()
+        effectCancellable?.cancel()
+    }
+    
+}


### PR DESCRIPTION
…ens in iOS

This commit introduces ViewModels for three screens in the iOS application: OnBoarding, AddTransaction, and AddGoal. These ViewModels handle the UI state and effects for their respective screens.

-   **OnBoardingViewModel:**
    -   Implements `OnBoardingViewModel` to manage the `OnBoardingState` and `OnBoardingEffect`.
    -   Includes methods to initialize data, handle events, and observe UI state and effects.
    -   Uses Combine framework for reactive programming.
-   **AddTransactionViewModel:**
    -   Implements `AddTransactionViewModel` to manage the `AddTransactionState`.
    -   Includes methods to initialize data with a transaction ID, handle events, and observe UI state.
    -   Uses Combine framework for reactive programming.
-   **AddGoalViewModel:**
    -   Implements `AddGoalViewModel` to manage the `AddGoalState` and `AddGoalEffect`.
    -   Includes methods to initialize data with a goal ID, handle events, and observe UI state and effects.
    -   Uses Combine framework for reactive programming.
- General:
    -  Uses `createPublisher` from `KMPNativeCoroutinesCombine` to manage kotlin flows.
    -  Uses `sink` for Combine `Publisher`.
    - All ViewModels are deinitialized properly.